### PR TITLE
Tranq rework

### DIFF
--- a/scripts/ff_weapon_tranq.txt
+++ b/scripts/ff_weapon_tranq.txt
@@ -2,7 +2,7 @@ WeaponData
 {
 	// Weapon characteristics:
 	"CycleTime"	"1.5"		// Rate of fire
-	"CycleDecrement"	"5"	// Number of bullets fired per cycle
+	"CycleDecrement"	"1"	// Number of bullets fired per cycle
 
 	"Damage"	"18"		// Damage per burst
 
@@ -23,9 +23,9 @@ WeaponData
 
 	"clip_size"	"-1"
 	"clip2_size"	"-1"
-	"default_clip"	"60"
+	"default_clip"	"20"
 	"default_clip2"	"-1"
-	"primary_ammo"	"AMMO_NAILS"
+	"primary_ammo"	"AMMO_CELLS"
 	"secondary_ammo"	"None"
 	
 	"ffencrypted"	"1" // required for the script to load
@@ -66,7 +66,7 @@ WeaponData
 		"ammo"
 		{
 			"font"	"WeaponIconsSmall"
-			"character"	"7"
+			"character"	"6"
 		}
 		"crosshair"
 		{


### PR DESCRIPTION
the tranq now uses cells, uses 1 cell per shot, and has a reserve of 20 cells, giving Spy three different (and small) ammo pools to manage.