### PR TITLE
Revert rocket damage back to 102

### DIFF
--- a/scripts/ff_weapon_rpg.txt
+++ b/scripts/ff_weapon_rpg.txt
@@ -4,7 +4,7 @@ WeaponData
 	"CycleTime"	"0.8"
 	"CycleDecrement"	"1"	// Number of bullets fired per cycle
 
-	"Damage"	"108"		// Damage per burst (~90)
+	"Damage"	"102"		// Damage per burst
 
 	"RecoilAmount"	"1"	// Amount of recoil
 


### PR DESCRIPTION
Hlieb and I found that inconsistencies are worse with 108 damage.